### PR TITLE
Fix error cleaning files in PowerShell and enable again associated lines

### DIFF
--- a/Tasks/PushToHeroku/PushToHeroku.ps1
+++ b/Tasks/PushToHeroku/PushToHeroku.ps1
@@ -109,14 +109,14 @@ Write-Host "Setting working directory to '$GitDirectory'"
     Set-Location $GitDirectory
 
 
-#Write-Host "Cleaning up files"
-#    Get-ChildItem -Recurse -Force  | `
-#        ?{ $_.FullName -notlike "*.git*" } | `
-#            Remove-Item -Force -Confirm:$false
-#            
-#    Write-Verbose "Files after cleaning up: "
-#    Get-ChildItem -Recurse -Force | %{ Write-Verbose $_.FullName }
-#Write-Host "Files cleaned"
+Write-Host "Cleaning up files"
+    Get-ChildItem -Recurse -Force  | `
+        ?{ $_.FullName -notlike "*.git*" } | `
+            Remove-Item -Recurse -Force -Confirm:$false
+    
+    Write-Verbose "Files after cleaning up: "
+    Get-ChildItem -Recurse -Force | %{ Write-Verbose $_.FullName }
+Write-Host "Files cleaned"
     
 
 Write-Host "Copying files from '$PushRoot'"


### PR DESCRIPTION
@FernandoMorais, fixed issue #2 cleaning files in PowerShell and enabling again associated lines to take care about deleted and renamed files. Would it be possible to include the modification in the next plugin Release and also update TFS Marketplace?